### PR TITLE
gh-1 : open & close persistent store on use

### DIFF
--- a/internal/safe/safe_test.go
+++ b/internal/safe/safe_test.go
@@ -33,10 +33,9 @@ func newFile(t *testing.T) string {
 }
 
 func TestSafe_Set(t *testing.T) {
-	b, err := New(newFile(t))
-	require.NoError(t, err)
+	b := New(newFile(t))
 
-	_, err = b.Get("does-not-exist")
+	_, err := b.Get("does-not-exist")
 	require.EqualError(t, err, "namespace \"does-not-exist\" does not exist")
 
 	// set ns1 first time
@@ -97,17 +96,13 @@ func TestSafe_Set(t *testing.T) {
 			"key3": []byte("value4"),
 		},
 	}, ns1)
-
-	err = b.(*box).Close()
-	require.NoError(t, err)
 }
 
 func TestSafe_Purge(t *testing.T) {
-	b, err := New(newFile(t))
-	require.NoError(t, err)
+	b := New(newFile(t))
 
 	// set ns1
-	err = b.Set(&Namespace{
+	err := b.Set(&Namespace{
 		Name: "ns1",
 		Content: map[string]Encrypted{
 			"key1": []byte("value1"),
@@ -134,17 +129,13 @@ func TestSafe_Purge(t *testing.T) {
 	// ensure ns1 is not set anymore
 	_, err = b.Get("ns1")
 	require.EqualError(t, err, `namespace "ns1" does not exist`)
-
-	err = b.(*box).Close()
-	require.NoError(t, err)
 }
 
 func TestSafe_Update(t *testing.T) {
-	b, err := New(newFile(t))
-	require.NoError(t, err)
+	b := New(newFile(t))
 
 	// set ns1
-	err = b.Set(&Namespace{
+	err := b.Set(&Namespace{
 		Name: "ns1",
 		Content: map[string]Encrypted{
 			"key1": []byte("value1"),
@@ -185,7 +176,4 @@ func TestSafe_Update(t *testing.T) {
 			"key3": []byte("value3"),
 		},
 	}, ns1)
-
-	err = b.(*box).Close()
-	require.NoError(t, err)
 }

--- a/internal/setup/tool.go
+++ b/internal/setup/tool.go
@@ -22,14 +22,9 @@ func New(file string, w output.Writer) *Tool {
 		panic(err)
 	}
 
-	box, err := safe.New(dbFile)
-	if err != nil {
-		panic(err)
-	}
-
 	return &Tool{
 		Writer: w,
 		Ring:   keyring.New(keyring.Init(envyKeyringName)),
-		Box:    box,
+		Box:    safe.New(dbFile),
 	}
 }


### PR DESCRIPTION
Enable using envy concurrently by only holding a
lock on the boltdb when we actually need it (i.e.
open and close the boltdb on every CRUD operation).

Since there is no concept of Compare And Set operations
spanning calls to the datastore, this is totally fine.

Fixes #1 