### PR TITLE
Add support for executing cmd with vars inlined

### DIFF
--- a/internal/commands/exec.go
+++ b/internal/commands/exec.go
@@ -29,6 +29,7 @@ func NewExecCmd(t *setup.Tool) subcommands.Command {
 		writer:        t.Writer,
 		ring:          t.Ring,
 		box:           t.Box,
+		execInputStd:  os.Stdin,
 		execOutputStd: os.Stdout,
 		execOutputErr: os.Stderr,
 	}
@@ -38,6 +39,7 @@ type execCmd struct {
 	writer        output.Writer
 	ring          keyring.Ring
 	box           safe.Box
+	execInputStd  io.Reader
 	execOutputStd io.Writer
 	execOutputErr io.Writer
 }
@@ -130,6 +132,7 @@ func (wc execCmd) newCmd(ns *safe.Namespace, insulate bool, argVars []string, co
 	cmd.Env = append(wc.env(ns, envContext(insulate)), argVars...)
 	cmd.Stdout = wc.execOutputStd
 	cmd.Stderr = wc.execOutputErr
+	cmd.Stdin = wc.execInputStd
 	return cmd
 }
 

--- a/internal/commands/exec.go
+++ b/internal/commands/exec.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/google/subcommands"
 	"github.com/shoenig/envy/internal/keyring"
@@ -72,7 +73,8 @@ func (wc execCmd) Execute(_ context.Context, fs *flag.FlagSet, _ ...interface{})
 		return subcommands.ExitUsageError
 	}
 
-	cmd := wc.newCmd(ns, insulate, fs.Arg(1), fs.Args()[2:])
+	argVars, command, args := splitArgs(fs.Args()[1:])
+	cmd := wc.newCmd(ns, insulate, argVars, command, args)
 	if err := cmd.Run(); err != nil {
 		wc.writer.Errorf("failed to exec: %v", err)
 		return subcommands.ExitFailure
@@ -81,10 +83,51 @@ func (wc execCmd) Execute(_ context.Context, fs *flag.FlagSet, _ ...interface{})
 	return subcommands.ExitSuccess
 }
 
-func (wc execCmd) newCmd(ns *safe.Namespace, insulate bool, command string, args []string) *exec.Cmd {
+// splitArgs will split the list of flag.Args() into:
+// in-lined env vars, command, command args
+func splitArgs(flagArgs []string) (argVars []string, command string, commandArgs []string) {
+	var (
+		startIdx   = 0
+		commandIdx = 0
+	)
+
+	// Special case for when variables are injected in the form: "env FOO=BAR command"
+	if flagArgs[0] == "env" {
+		startIdx++
+		commandIdx++
+	}
+
+	for commandIdx < len(flagArgs) {
+		_, err := exec.LookPath(flagArgs[commandIdx])
+		if err != nil && strings.Contains(flagArgs[commandIdx], "=") {
+			// Assume that arguments not in the path and with an equal sign are env vars.
+			commandIdx++
+		} else {
+			break
+		}
+	}
+
+	// Only detected environment-setting, fall back to assuming the first is the command.
+	if commandIdx >= len(flagArgs) {
+		return nil, flagArgs[0], flagArgs[1:]
+	}
+
+	command = flagArgs[commandIdx]
+	argVars = flagArgs[startIdx:commandIdx]
+	commandArgs = flagArgs[commandIdx+1:]
+
+	return argVars, command, commandArgs
+}
+
+func (wc execCmd) newCmd(ns *safe.Namespace, insulate bool, argVars []string, command string, args []string) *exec.Cmd {
 	ctx := context.Background()
 	cmd := exec.CommandContext(ctx, command, args...)
-	cmd.Env = wc.env(ns, envContext(insulate))
+
+	// Environment variables are injected in the following order:
+	// 1. OS variables if insulate is false
+	// 2. envy namespace vars
+	// 3. Variables in input args
+	cmd.Env = append(wc.env(ns, envContext(insulate)), argVars...)
 	cmd.Stdout = wc.execOutputStd
 	cmd.Stderr = wc.execOutputErr
 	return cmd

--- a/internal/commands/exec_test.go
+++ b/internal/commands/exec_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 
@@ -152,5 +153,99 @@ func TestExecCmd_Execute_badCommand(t *testing.T) {
 		must.Eq(t, "envy: failed to exec: exec: \"/does/not/exist\": file does not exist\n", b.String())
 	default:
 		must.Eq(t, "envy: failed to exec: fork/exec /does/not/exist: no such file or directory\n", b.String())
+	}
+}
+
+func Test_splitArgs(t *testing.T) {
+	type args struct {
+		flagArgs []string
+	}
+	tests := map[string]struct {
+		setup           func()
+		args            args
+		wantArgVars     []string
+		wantCommand     string
+		wantCommandArgs []string
+	}{
+		"no env vars": {
+			args: args{
+				flagArgs: []string{"cat", "log.out"},
+			},
+			wantArgVars:     []string{},
+			wantCommand:     "cat",
+			wantCommandArgs: []string{"log.out"},
+		},
+		"env vars with command but no args": {
+			args: args{
+				flagArgs: []string{"FOO=BAR", "ZIP=ZAP", "ls"},
+			},
+			wantArgVars:     []string{"FOO=BAR", "ZIP=ZAP"},
+			wantCommand:     "ls",
+			wantCommandArgs: []string{},
+		},
+		"env vars with command and args": {
+			args: args{
+				flagArgs: []string{"FOO=BAR", "ZIP=ZAP", "curl", "-k", "localhost:8501"},
+			},
+			wantArgVars:     []string{"FOO=BAR", "ZIP=ZAP"},
+			wantCommand:     "curl",
+			wantCommandArgs: []string{"-k", "localhost:8501"},
+		},
+		"explicit env": {
+			args: args{
+				flagArgs: []string{"env", "FOO=BAR", "ZIP=ZAP", "curl", "-k", "localhost:8501"},
+			},
+			wantArgVars:     []string{"FOO=BAR", "ZIP=ZAP"},
+			wantCommand:     "curl",
+			wantCommandArgs: []string{"-k", "localhost:8501"},
+		},
+		"only env": {
+			args: args{
+				flagArgs: []string{"env"},
+			},
+			wantArgVars:     nil,
+			wantCommand:     "env",
+			wantCommandArgs: []string{},
+		},
+		"all vars and none in path": {
+			args: args{
+				flagArgs: []string{"FOO=BAR", "ZIP=ZAP", "BIP=BOP"},
+			},
+			wantArgVars:     nil,
+			wantCommand:     "FOO=BAR",
+			wantCommandArgs: []string{"ZIP=ZAP", "BIP=BOP"},
+		},
+		"cmd with equal in path is allowed": {
+			setup: func() {
+				tempDir, err := os.MkdirTemp("", "envy")
+				must.NoError(t, err)
+				t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+				f, err := os.OpenFile(filepath.Join(tempDir, "my=cmd"), os.O_CREATE|os.O_EXCL, 0700)
+				must.NoError(t, err)
+				must.NoError(t, f.Close())
+
+				err = os.Setenv("PATH", tempDir)
+				must.NoError(t, err)
+			},
+			args: args{
+				flagArgs: []string{"FOO=BAR", "my=cmd", "ZIP=ZAP"},
+			},
+			wantArgVars:     []string{"FOO=BAR"},
+			wantCommand:     "my=cmd",
+			wantCommandArgs: []string{"ZIP=ZAP"},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup()
+			}
+			gotArgVars, gotCommand, gotCommandArgs := splitArgs(tt.args.flagArgs)
+
+			must.Eq(t, tt.wantArgVars, gotArgVars)
+			must.Eq(t, tt.wantCommand, gotCommand)
+			must.Eq(t, tt.wantCommandArgs, gotCommandArgs)
+		})
 	}
 }

--- a/internal/commands/exec_test.go
+++ b/internal/commands/exec_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/google/subcommands"
@@ -54,6 +55,7 @@ func TestExecCmd_Execute(t *testing.T) {
 		box:           box,
 		execOutputStd: &c,
 		execOutputErr: &d,
+		execInputStd:  strings.NewReader("ok\n"),
 	}
 
 	box.GetMock.Expect("myNS").Return(&safe.Namespace{
@@ -75,7 +77,7 @@ func TestExecCmd_Execute(t *testing.T) {
 	must.Eq(t, subcommands.ExitSuccess, rc)
 	must.Eq(t, "", a.String())
 	must.Eq(t, "", b.String())
-	must.Eq(t, "a is passw0rd\nb is hunter2\n", c.String())
+	must.Eq(t, "a is passw0rd\nb is hunter2\nok\n", c.String())
 	must.Eq(t, "", d.String())
 }
 

--- a/internal/commands/testing/a.sh
+++ b/internal/commands/testing/a.sh
@@ -4,3 +4,6 @@ set -euo pipefail
 
 echo "a is ${a}"
 echo "b is ${b}"
+
+read input
+echo "$input"


### PR DESCRIPTION
Previously exec would consider the first flag arg to be the command and
all later args to be command args.

This commit updates that behavior so that individual environment
variables can be overwritten as needed. For example, an envy namespace
may have a baseline value for the variable FOO that should be
overwritten with an ephemeral value that shouldn't be stored.

There is support for the following formats:

- env FOO=BAR [command] [args...]
- FOO=BAR [command] [args...]

Also made an update to allow spinning up commands that read from stdin.